### PR TITLE
Fix #8

### DIFF
--- a/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
@@ -9,8 +9,10 @@ import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.gl.SimpleFramebuffer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.ChatHudLine;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.util.ScreenshotRecorder;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
@@ -70,8 +72,16 @@ public class ChatCopyUtil {
             width = Math.max(width, client.textRenderer.getWidth(content));
         }
         int height = lines.size() * 9;
+        Framebuffer fb;
+        try {
+             fb = createBuffer(width * scaleFactor, height * scaleFactor);
+        } catch (IllegalArgumentException e) {
+            // If we get this error that mean the window is too big or the chat is empty
+            ClientPlayerEntity player = client.player;
+            player.sendMessage(Text.translatable("chatshot.noMessageFound"));
+            return;
+        }
 
-        Framebuffer fb = createBuffer(width * scaleFactor, height * scaleFactor);
         context.getMatrices().scale((float) client.getWindow().getScaledWidth() / width, (float) client.getWindow().getScaledHeight() / height, 1f);
         fb.beginWrite(false);
         int y = 0;
@@ -128,7 +138,9 @@ public class ChatCopyUtil {
     }
 
     private static Framebuffer createBuffer(int width, int height) {
+        //
         Framebuffer fb = new SimpleFramebuffer(width, height, true, false);
+        //
         fb.setClearColor(0x36 / 255f, 0x39 / 255f, 0x3F / 255f, 0f);
         fb.clear(false);
         return fb;

--- a/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
@@ -77,8 +77,7 @@ public class ChatCopyUtil {
              fb = createBuffer(width * scaleFactor, height * scaleFactor);
         } catch (IllegalArgumentException e) {
             // If we get this error that mean the window is too big or the chat is empty
-            ClientPlayerEntity player = client.player;
-            player.sendMessage(Text.translatable("chatshot.noMessageFound"));
+            client.inGameHud.getChatHud().addMessage(Text.translatable("chatshot.noMessageFound"));
             return;
         }
 
@@ -138,9 +137,7 @@ public class ChatCopyUtil {
     }
 
     private static Framebuffer createBuffer(int width, int height) {
-        //
         Framebuffer fb = new SimpleFramebuffer(width, height, true, false);
-        //
         fb.setClearColor(0x36 / 255f, 0x39 / 255f, 0x3F / 255f, 0f);
         fb.clear(false);
         return fb;

--- a/src/main/resources/assets/chatshot/lang/en_us.json
+++ b/src/main/resources/assets/chatshot/lang/en_us.json
@@ -23,5 +23,6 @@
   "chatshot.copyOption.text": "Copy as Text",
   "chatshot.copyOption.image": "Copy as Image",
   "chatshot.saveImage": "Save Image",
-  "chatshot.saveImage.description": "Save the image of the chat you made to .minecraft/screenshots/chat"
+  "chatshot.saveImage.description": "Save the image of the chat you made to .minecraft/screenshots/chat",
+  "chatshot.noMessageFound": "§4The chat is empty"
 }


### PR DESCRIPTION
Like said in #8 when you copy an empty chat the game just crashes because you didn't catch an IllegalArgumentException
Here is my log when trying to reproduce the bug

Note: Haven't on test other version than fabric 1.21 but it should work