### PR TITLE
fix: copy not using full message

### DIFF
--- a/src/main/java/dev/dediamondpro/chatshot/data/ChatHudLocals.java
+++ b/src/main/java/dev/dediamondpro/chatshot/data/ChatHudLocals.java
@@ -1,7 +1,11 @@
 package dev.dediamondpro.chatshot.data;
 
+import net.minecraft.network.chat.Component;
+
 public interface ChatHudLocals {
     int chatShot$getChatY();
 
     int chatShot$getChatBackgroundColor();
+
+    Component chatshot$getMessageForLine(int index);
 }

--- a/src/main/java/dev/dediamondpro/chatshot/mixins/ChatScreenMixin.java
+++ b/src/main/java/dev/dediamondpro/chatshot/mixins/ChatScreenMixin.java
@@ -1,8 +1,8 @@
 package dev.dediamondpro.chatshot.mixins;
 
-import dev.dediamondpro.chatshot.data.ChatHudLocals;
 import dev.dediamondpro.chatshot.compat.CompatCore;
 import dev.dediamondpro.chatshot.config.Config;
+import dev.dediamondpro.chatshot.data.ChatHudLocals;
 import dev.dediamondpro.chatshot.util.ChatCopyUtil;
 import dev.dediamondpro.chatshot.util.Textures;
 import net.minecraft.client.GuiMessage;
@@ -89,7 +89,7 @@ public abstract class ChatScreenMixin extends Screen {
                 messageParts.addFirst(visibleMessages.get(i));
             }
             if (messageParts.isEmpty()) return;
-            ChatCopyUtil.copy(messageParts, this.minecraft);
+            ChatCopyUtil.copy(messageParts, chatHudL.chatshot$getMessageForLine(chatLineY), this.minecraft);
         }
     }
 

--- a/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
@@ -54,22 +54,28 @@ public class ChatCopyUtil {
                     .setOutputState(new RenderStateShard.OutputStateShard("chatshot_fbo", () -> (rt)))
                     .setLightmapState(RenderStateShard.LIGHTMAP).createCompositeState(false)));
 
-    public static void copy(List<GuiMessage.Line> lines, Minecraft client) {
+    public static void copy(List<GuiMessage.Line> lines, Component fullMessage, Minecraft client) {
         if (GLFW.glfwGetKey(client.getWindow().getWindow(), GLFW.GLFW_KEY_LEFT_SHIFT) == GLFW.GLFW_PRESS || GLFW.glfwGetKey(client.getWindow().getWindow(), GLFW.GLFW_KEY_RIGHT_SHIFT) == GLFW.GLFW_PRESS) {
-            if (Config.INSTANCE.shiftClickAction == Config.CopyType.TEXT) copyString(lines, client);
+            if (Config.INSTANCE.shiftClickAction == Config.CopyType.TEXT) copyString(lines, fullMessage, client);
             else copyImage(lines, client);
         } else {
-            if (Config.INSTANCE.clickAction == Config.CopyType.TEXT) copyString(lines, client);
+            if (Config.INSTANCE.clickAction == Config.CopyType.TEXT) copyString(lines, fullMessage, client);
             else copyImage(lines, client);
         }
     }
 
-    public static void copyString(List<GuiMessage.Line> lines, Minecraft client) {
-        CollectingCharacterVisitor visitor = new CollectingCharacterVisitor();
-        for (GuiMessage.Line line : lines) {
-            line.content().accept(visitor);
+    public static void copyString(List<GuiMessage.Line> lines, Component fullMessage, Minecraft client) {
+        String clipboardString;
+        if (fullMessage == null) {
+            CollectingCharacterVisitor visitor = new CollectingCharacterVisitor();
+            for (GuiMessage.Line line : lines) {
+                line.content().accept(visitor);
+            }
+            clipboardString = visitor.collect();
+        } else {
+            clipboardString = fullMessage.getString();
         }
-        client.keyboardHandler.setClipboard(visitor.collect());
+        client.keyboardHandler.setClipboard(clipboardString);
         if (Config.INSTANCE.showCopyMessage) {
             client.gui.getChat().addMessage(Component.translatable("chatshot.text.success"));
         }


### PR DESCRIPTION
Fixes copying a message not copying the full message resulting in spaces being at the end of each line

Top is old 
> \<Player642> dfkohsdjhfgjhfdsh jkfhjsdhsdjflhsfdl hklsdfhksdflshkldfs fdhkl
> \<Player642> dfkohsdjhfgjhfdshjkfhjsdhsdjflhsfdlhklsdfhksdflshkldfsfdhkl
Bottom is this PR

I left the old char collector in case of not being able to find the full message, I can remove this fallback if youd like