### PR TITLE
fix: uppercase formatting characters not being stripped

### DIFF
--- a/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
@@ -93,7 +93,7 @@ public class ChatCopyUtil {
         }
     }
 
-    private static Pattern formattingPattern = Pattern.compile("§[0-9a-z]");
+    private static Pattern formattingPattern = Pattern.compile("§[0-9a-z]", Pattern.CASE_INSENSITIVE);
     public static void copyString(List<GuiMessage.Line> lines, Component fullMessage, Minecraft client) {
         String clipboardString;
         if (fullMessage == null) {


### PR DESCRIPTION
Fixed uppercase formatting codes (e.g. `§A`) not being stripped when copying messages.