### PR TITLE
fix: skip mod widget components (e.g. Chat Heads) when copying chat text

### DIFF
--- a/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
@@ -93,7 +93,7 @@ public class ChatCopyUtil {
         }
     }
 
-    private static Pattern formattingPattern = Pattern.compile("§[0-9a-z]");
+    private static Pattern formattingPattern = Pattern.compile("§[0-9a-z]", Pattern.CASE_INSENSITIVE);
     public static void copyString(List<GuiMessage.Line> lines, Component fullMessage, Minecraft client) {
         String clipboardString;
         if (fullMessage == null) {

--- a/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/ChatCopyUtil.java
@@ -95,17 +95,14 @@ public class ChatCopyUtil {
 
     private static Pattern formattingPattern = Pattern.compile("§[0-9a-z]", Pattern.CASE_INSENSITIVE);
     public static void copyString(List<GuiMessage.Line> lines, Component fullMessage, Minecraft client) {
-        String clipboardString;
-        if (fullMessage == null) {
-            CollectingCharacterVisitor visitor = new CollectingCharacterVisitor();
-            for (GuiMessage.Line line : lines) {
-                line.content().accept(visitor);
-            }
-            clipboardString = visitor.collect();
-        } else {
-            clipboardString = fullMessage.getString();
+        // Always use the FormattedCharSequence visitor path so that mod-injected widget
+        // components (e.g. Chat Heads player heads whose getString() returns "[name head]")
+        // are never included in the copied text.
+        CollectingCharacterVisitor visitor = new CollectingCharacterVisitor();
+        for (GuiMessage.Line line : lines) {
+            line.content().accept(visitor);
         }
-        clipboardString = formattingPattern.matcher(clipboardString).replaceAll("");
+        String clipboardString = formattingPattern.matcher(visitor.collect()).replaceAll("");
         client.keyboardHandler.setClipboard(clipboardString);
         if (Config.INSTANCE.showCopyMessage) {
             client.gui.getChat().addMessage(Component.translatable("chatshot.text.success"));

--- a/src/main/java/dev/dediamondpro/chatshot/util/CollectingCharacterVisitor.java
+++ b/src/main/java/dev/dediamondpro/chatshot/util/CollectingCharacterVisitor.java
@@ -8,7 +8,13 @@ public class CollectingCharacterVisitor implements FormattedCharSink {
 
     @Override
     public boolean accept(int index, Style style, int codePoint) {
-        builder.append((char) codePoint);
+        // Skip private-use area characters (U+E000–U+F8FF, U+F0000–U+FFFFF) used by mods
+        // for custom glyphs/widgets (e.g. Chat Heads player head placeholders).
+        if ((codePoint >= 0xE000 && codePoint <= 0xF8FF)
+                || (codePoint >= 0xF0000 && codePoint <= 0xFFFFF)) {
+            return true;
+        }
+        builder.appendCodePoint(codePoint);
         return true;
     }
 


### PR DESCRIPTION
based on #28 pr